### PR TITLE
Ensure your security group blocks unwanted inbound traffic

### DIFF
--- a/src/cluster.tf
+++ b/src/cluster.tf
@@ -32,14 +32,14 @@ resource "aws_security_group" "tfgoat-cluster" {
   name        = "${local.prefix}-tfgoat-cluster"
   description = "Cluster communication with worker nodes"
   vpc_id      = aws_vpc.tfgoat.id
-
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    # [Shisho]: You can ignore this report by adding the following comment:
+    # shisho: mark-as-intended aws-vpc-ensure-sg-ingress-cidr-is-well-configured
+    cidr_blocks = [ "0.0.0.0/0" ]
   }
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -47,6 +47,7 @@ resource "aws_security_group" "tfgoat-cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
 
 resource "aws_security_group_rule" "tfgoat-cluster-ingress-workstation-https" {
   cidr_blocks       = ["0.0.0.0/0"]


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

Your security group allows ingress traffic from all IPs, exposing resources in the VPC to unwanted attacks. If it is intentional, you can help your colleagues by leaving a comment that says it is intentionally done so.

